### PR TITLE
Fix KeyError in calc_diff when old_tree node missing 'd' key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ packages = [
   { include = "pyview" },
 ]
 
-version = "0.7.2"
+version = "0.7.3"
 description = "LiveView in Python"
 authors = ["Larry Ogrodnek <ogrodnek@gmail.com>"]
 license = "MIT"

--- a/pyview/template/render_diff.py
+++ b/pyview/template/render_diff.py
@@ -15,7 +15,7 @@ def calc_diff(old_tree: dict[str, Any], new_tree: dict[str, Any]) -> dict[str, A
             old_static = old_tree[key].get("s", [])
             new_static = new_tree[key]["s"]
 
-            old_dynamic = old_tree[key]["d"]
+            old_dynamic = old_tree[key].get("d", [])
             new_dynamic = new_tree[key]["d"]
 
             if old_static != new_static:

--- a/tests/template/test_diff.py
+++ b/tests/template/test_diff.py
@@ -117,3 +117,29 @@ def test_nested_string_to_dict():
     new = {"a": {"b": {"s": [42]}}}
 
     assert calc_diff(old, new) == {"a": {"b": {"s": [42]}}}
+
+
+def test_dict_missing_d_key():
+    """
+    Test when old dict has "s" but not "d" - can happen with conditional template changes.
+    """
+    # Old has statics but no dynamics (malformed or transitional state)
+    old = {"0": {"s": ["<span>", "</span>"]}}
+
+    # New has both statics and dynamics
+    new = {"0": {"s": ["<span>", "</span>"], "d": [["Item1"], ["Item2"]]}}
+
+    # Should return the dynamics since statics match but dynamics changed from "missing" to values
+    assert calc_diff(old, new) == {"0": {"d": [["Item1"], ["Item2"]]}}
+
+
+def test_dict_missing_both_s_and_d():
+    """
+    Test when old dict has neither "s" nor "d" - completely different structure.
+    """
+    old = {"0": {"foo": "bar", "baz": 123}}
+
+    new = {"0": {"s": ["<div>", "</div>"], "d": [["A"]]}}
+
+    # Should return full new structure
+    assert calc_diff(old, new) == {"0": {"s": ["<div>", "</div>"], "d": [["A"]]}}


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'd'` in `calc_diff` when old tree node has different structure than new tree
- Use `.get("d", [])` to match existing pattern for "s" key on previous line
- Add tests for missing "d" key and missing both "s" and "d" keys
- Bump version to 0.7.3

## Problem
When comparing tree structures, `calc_diff` assumed `old_tree[key]` would always have a "d" key if `new_tree[key]` had both "s" and "d". This caused a KeyError when `old_tree[key]` was a dict with a different structure (e.g., during template structure changes or conditional imports).

## Test plan
- [x] Added `test_dict_missing_d_key` - old has "s" but not "d"
- [x] Added `test_dict_missing_both_s_and_d` - old has completely different structure
- [x] All existing diff tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)