### PR TITLE
  Fix websocket timeout when components are removed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyview-web"
-version = "0.8.2"
+version = "0.8.3"
 description = "LiveView in Python"
 authors = [{ name = "Larry Ogrodnek", email = "ogrodnek@gmail.com" }]
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -879,7 +879,7 @@ wheels = [
 
 [[package]]
 name = "pyview-web"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
  Add handlers for cids_will_destroy and cids_destroyed events.
  Phoenix client expects acknowledgment for these messages, otherwise
  it times out after 30 seconds and reloads the page.

  Fixes #121