### PR TITLE
Fixes #127

### DIFF
--- a/pyview/template/live_view_template.py
+++ b/pyview/template/live_view_template.py
@@ -122,6 +122,12 @@ class LiveViewTemplate:
                 # Get the actual value from the interpolation
                 interp_value = item.value
 
+                # None is rendered as empty string
+                if interp_value is None:
+                    parts[key] = ""
+                    interp_index += 1
+                    continue
+
                 # Apply format specifier if present
                 if hasattr(item, "format_spec") and item.format_spec:
                     try:

--- a/tests/test_live_view_template.py
+++ b/tests/test_live_view_template.py
@@ -225,10 +225,22 @@ class TestLiveViewTemplate:
         
         expected = {
             "s": ["Value: ", ""],
-            "0": "None"  # None is converted to string
+            "0": ""  # None renders as empty string
         }
         assert result == expected
     
+    def test_none_with_format_spec(self):
+        """Test None with a format spec still renders as empty string."""
+        value = None
+        template = t"Price: {value:.2f}"
+        result = LiveViewTemplate.process(template)
+
+        expected = {
+            "s": ["Price: ", ""],
+            "0": ""  # None renders as empty string
+        }
+        assert result == expected
+
     def test_dict_interpolation(self):
         """Test dictionary interpolation."""
         data = {"key": "value", "num": 42}


### PR DESCRIPTION
Render `None` as empty string in t-string templates.  We had a similar thing in the ibis templates where undefined values would get converted to ibis.context.Undefined, which rendered as None.

This seems like the right default and should be easy enough to work around by using str(val) if you want to see `None` in template output.