### PR TITLE
Fix KeyError on payload["url"] in phx_join redirect

### DIFF
--- a/examples/example_registry.py
+++ b/examples/example_registry.py
@@ -13,6 +13,8 @@ from .views import (
     JsCommandsLiveView,
     KanbanLiveView,
     MapLiveView,
+    PageALiveView,
+    PageBLiveView,
     PingLiveView,
     PlantsLiveView,
     PodcastLiveView,
@@ -41,6 +43,8 @@ routes: list[tuple[str, type[LiveView], list[str]]] = [
     ("/includes", IncludesLiveView, ["basics"]),
     ("/streams", StreamsDemoLiveView, ["realtime", "advanced"]),
     ("/flash", FlashDemoLiveView, ["basics"]),
+    ("/redirect_a", PageALiveView, ["basics"]),
+    ("/redirect_b", PageBLiveView, ["basics"]),
 ]
 
 # T-string examples are only available on Python 3.14+

--- a/examples/views/__init__.py
+++ b/examples/views/__init__.py
@@ -18,6 +18,7 @@ from .registration import RegistrationLiveView
 from .status import StatusLiveView
 from .streams import StreamsDemoLiveView
 from .volume import VolumeLiveView
+from .redirect_repro import PageALiveView, PageBLiveView
 from .webping import PingLiveView
 
 if sys.version_info >= (3, 14):
@@ -42,6 +43,8 @@ __all__ = [
     "IncludesLiveView",
     "StreamsDemoLiveView",
     "FlashDemoLiveView",
+    "PageALiveView",
+    "PageBLiveView",
 ]
 
 if sys.version_info >= (3, 14):

--- a/examples/views/redirect_repro/__init__.py
+++ b/examples/views/redirect_repro/__init__.py
@@ -1,0 +1,1 @@
+from .redirect_repro import PageALiveView, PageBLiveView

--- a/examples/views/redirect_repro/page_a_live_view.html
+++ b/examples/views/redirect_repro/page_a_live_view.html
@@ -1,0 +1,14 @@
+<div class="max-w-md mx-auto">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <h1 class="text-3xl font-bold text-center text-gray-900 mb-4">Page A</h1>
+        <p class="text-center text-gray-600 mb-8">
+            Click the button to <code>redirect</code> to Page B.
+        </p>
+        <div class="text-center">
+            <button phx-click="go_to_b"
+                    class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors">
+                Go to Page B →
+            </button>
+        </div>
+    </div>
+</div>

--- a/examples/views/redirect_repro/page_b_live_view.html
+++ b/examples/views/redirect_repro/page_b_live_view.html
@@ -1,0 +1,14 @@
+<div class="max-w-md mx-auto">
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <h1 class="text-3xl font-bold text-center text-gray-900 mb-4">Page B</h1>
+        <p class="text-center text-gray-600 mb-8">
+            Click the button to <code>redirect</code> back to Page A.
+        </p>
+        <div class="text-center">
+            <button phx-click="go_to_a"
+                    class="px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors">
+                ← Go to Page A
+            </button>
+        </div>
+    </div>
+</div>

--- a/examples/views/redirect_repro/redirect_repro.py
+++ b/examples/views/redirect_repro/redirect_repro.py
@@ -1,0 +1,44 @@
+"""Redirect repro: Two pages that use live_redirect to navigate between each other.
+
+This triggers the `redirect=true` path in the Phoenix LiveView JS client,
+which sends a phx_join payload with `redirect` instead of `url`.
+"""
+
+from typing import TypedDict
+
+from pyview import LiveView, LiveViewSocket
+
+
+class PageContext(TypedDict):
+    page: str
+
+
+class PageALiveView(LiveView[PageContext]):
+    """
+    Redirect Repro — Page A
+
+    Click the link to live_redirect to Page B. This exercises the redirect
+    payload path in the WebSocket handler.
+    """
+
+    async def mount(self, socket: LiveViewSocket[PageContext], session):
+        socket.context = PageContext(page="A")
+
+    async def handle_event(self, event: str, socket: LiveViewSocket[PageContext]):
+        if event == "go_to_b":
+            await socket.redirect("/redirect_b")
+
+
+class PageBLiveView(LiveView[PageContext]):
+    """
+    Redirect Repro — Page B
+
+    Click the link to live_redirect back to Page A.
+    """
+
+    async def mount(self, socket: LiveViewSocket[PageContext], session):
+        socket.context = PageContext(page="B")
+
+    async def handle_event(self, event: str, socket: LiveViewSocket[PageContext]):
+        if event == "go_to_a":
+            await socket.redirect("/redirect_a")

--- a/pyview/ws_handler.py
+++ b/pyview/ws_handler.py
@@ -94,7 +94,8 @@ class LiveSocketHandler:
 
                 self.myJoinId = topic
 
-                url = urlparse(payload["url"])
+                url_str = payload.get("redirect") or payload.get("url")
+                url = urlparse(url_str)
                 lv_class, path_params = self.routes.get(url.path)
                 await self.check_auth(websocket, lv_class)
 
@@ -166,144 +167,238 @@ class LiveSocketHandler:
     async def _handle_connected_loop(self, myJoinId, socket: ConnectedLiveViewSocket):
         while True:
             message = await socket.websocket.receive()
+            # parse_message raises WebSocketDisconnect for disconnect frames,
+            # which propagates out of the loop — this is intentional.
             [joinRef, messageRef, topic, event, payload] = parse_message(message)
 
-            if event == "heartbeat":
-                resp = [
-                    None,
-                    messageRef,
-                    "phoenix",
-                    "phx_reply",
-                    {"response": {}, "status": "ok"},
-                ]
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                continue
+            try:
+                await self._dispatch_event(
+                    myJoinId, socket, joinRef, messageRef, topic, event, payload
+                )
+            except Exception:
+                logger.exception("Error handling event '%s'", event)
+                with suppress(Exception):
+                    resp = [
+                        joinRef,
+                        messageRef,
+                        topic,
+                        "phx_reply",
+                        {"response": {}, "status": "error"},
+                    ]
+                    await self.manager.send_personal_message(
+                        json.dumps(resp), socket.websocket
+                    )
 
-            if event == "event":
-                value = payload["value"]
+    async def _dispatch_event(
+        self, myJoinId, socket: ConnectedLiveViewSocket,
+        joinRef, messageRef, topic, event, payload,
+    ):
+        if event == "heartbeat":
+            resp = [
+                None,
+                messageRef,
+                "phoenix",
+                "phx_reply",
+                {"response": {}, "status": "ok"},
+            ]
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
 
-                if payload["type"] == "form":
-                    value = parse_qs(value)
-                    socket.upload_manager.maybe_process_uploads(value, payload)
+        if event == "event":
+            value = payload["value"]
 
-                # Track event metrics
-                event_name = payload["event"]
-                view_name = socket.liveview.__class__.__name__
+            if payload["type"] == "form":
+                value = parse_qs(value)
+                socket.upload_manager.maybe_process_uploads(value, payload)
 
-                # Handle built-in lv:clear-flash event
-                if event_name == "lv:clear-flash":
-                    raw_key = value.get("key") if isinstance(value, dict) else None
-                    socket.clear_flash(raw_key if isinstance(raw_key, str) else None)
-                else:
-                    # Check if event is targeted at a component (via phx-target={cid})
-                    target_cid = payload.get("cid")
+            # Track event metrics
+            event_name = payload["event"]
+            view_name = socket.liveview.__class__.__name__
 
-                    self.metrics.events_processed.add(1, {"event": event_name, "view": view_name})
+            # Handle built-in lv:clear-flash event
+            if event_name == "lv:clear-flash":
+                raw_key = value.get("key") if isinstance(value, dict) else None
+                socket.clear_flash(raw_key if isinstance(raw_key, str) else None)
+            else:
+                # Check if event is targeted at a component (via phx-target={cid})
+                target_cid = payload.get("cid")
 
-                    # Time event processing
-                    with self.instrumentation.time_histogram(
-                        "pyview.events.duration", {"event": event_name, "view": view_name}
-                    ):
-                        if target_cid is not None:
-                            # Validate CID type - must be an integer
-                            if not isinstance(target_cid, int):
-                                logger.warning(
-                                    f"Invalid cid type for event '{event_name}': {type(target_cid).__name__}"
-                                )
-                            else:
-                                # Route event to component
-                                await socket.components.handle_event(target_cid, event_name, value)
-                        else:
-                            # Route event to LiveView (default behavior)
-                            await call_handle_event(socket.liveview, event_name, value, socket)
+                self.metrics.events_processed.add(1, {"event": event_name, "view": view_name})
 
-                # Time rendering
+                # Time event processing
                 with self.instrumentation.time_histogram(
-                    "pyview.render.duration", {"view": view_name}
+                    "pyview.events.duration", {"event": event_name, "view": view_name}
                 ):
-                    rendered = await _render(socket)
+                    if target_cid is not None:
+                        # Validate CID type - must be an integer
+                        if not isinstance(target_cid, int):
+                            logger.warning(
+                                f"Invalid cid type for event '{event_name}': {type(target_cid).__name__}"
+                            )
+                        else:
+                            # Route event to component
+                            await socket.components.handle_event(target_cid, event_name, value)
+                    else:
+                        # Route event to LiveView (default behavior)
+                        await call_handle_event(socket.liveview, event_name, value, socket)
 
-                hook_events = {} if not socket.pending_events else {"e": socket.pending_events}
+            # Time rendering
+            with self.instrumentation.time_histogram(
+                "pyview.render.duration", {"view": view_name}
+            ):
+                rendered = await _render(socket)
 
-                diff = socket.diff(rendered)
+            hook_events = {} if not socket.pending_events else {"e": socket.pending_events}
 
-                socket.pending_events = []
+            diff = socket.diff(rendered)
+
+            socket.pending_events = []
+
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {"diff": diff | hook_events}, "status": "ok"},
+            ]
+            resp_json = json.dumps(resp)
+            self.metrics.message_size.record(len(resp_json))
+            await self.manager.send_personal_message(resp_json, socket.websocket)
+            return
+
+        if event == "live_patch":
+            lv = socket.liveview
+            url = urlparse(payload.get("url", ""))
+
+            # Extract and merge parameters
+            query_params = parse_qs(url.query)
+            path_params = {}
+
+            # We need to get path params for the new URL
+            with suppress(ValueError):
+                # TODO: I don't think this is actually going to work...
+                _, path_params = self.routes.get(url.path)
+
+            merged_params = {**query_params, **path_params}
+
+            await call_handle_params(lv, url, merged_params, socket)
+            rendered = await _render(socket)
+            diff = socket.diff(rendered)
+
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {"diff": diff}, "status": "ok"},
+            ]
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
+
+        if event == "cids_will_destroy":
+            # Client notifies that these CIDs are being removed from DOM
+            # Actual cleanup handled by prune_stale_components() during render
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {}, "status": "ok"},
+            ]
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
+
+        if event == "cids_destroyed":
+            # Client confirms CIDs have been fully removed from DOM
+            # Return the CIDs so client can prune its render cache
+            cids = payload.get("cids", [])
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {"cids": cids}, "status": "ok"},
+            ]
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
+
+        if event == "allow_upload":
+            allow_upload_response = await socket.upload_manager.process_allow_upload(
+                payload, socket.context
+            )
+
+            rendered = await _render(socket)
+            diff = socket.diff(rendered)
+
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {
+                    "response": {"diff": rendered} | allow_upload_response,
+                    "status": "ok",
+                },
+            ]
+
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
+
+        # file upload or navigation
+        if event == "phx_join":
+            # Check if this is a file upload join (topic starts with "lvu:")
+            if topic.startswith("lvu:"):
+                # This is a file upload join
+                socket.upload_manager.add_upload(joinRef, payload)
 
                 resp = [
                     joinRef,
                     messageRef,
                     topic,
                     "phx_reply",
-                    {"response": {"diff": diff | hook_events}, "status": "ok"},
+                    {"response": {}, "status": "ok"},
                 ]
-                resp_json = json.dumps(resp)
-                self.metrics.message_size.record(len(resp_json))
-                await self.manager.send_personal_message(resp_json, socket.websocket)
-                continue
 
-            if event == "live_patch":
-                lv = socket.liveview
-                url = urlparse(payload["url"])
+                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            else:
+                # This is a navigation join (topic starts with "lv:")
+                # Navigation payload has 'redirect' field instead of 'url'
+                url_str_raw = payload.get("redirect") or payload.get("url")
+                url_str: str = (
+                    url_str_raw.decode("utf-8")
+                    if isinstance(url_str_raw, bytes)
+                    else str(url_str_raw)
+                )
+                url = urlparse(url_str)
+                lv_class, path_params = self.routes.get(url.path)
+                await self.check_auth(socket.websocket, lv_class)
 
-                # Extract and merge parameters
+                session = {}
+                if "session" in payload:
+                    session = deserialize_session(payload["session"])
+
+                lv = create_view(lv_class, session)
+
+                # Create new socket for new LiveView
+                socket = ConnectedLiveViewSocket(
+                    socket.websocket,
+                    topic,
+                    lv,
+                    self.scheduler,
+                    self.instrumentation,
+                    self.routes,
+                )
+
+                await call_mount(lv, socket, session)
+
+                # Parse query parameters and merge with path parameters
                 query_params = parse_qs(url.query)
-                path_params = {}
-
-                # We need to get path params for the new URL
-                with suppress(ValueError):
-                    # TODO: I don't think this is actually going to work...
-                    _, path_params = self.routes.get(url.path)
-
                 merged_params = {**query_params, **path_params}
 
                 await call_handle_params(lv, url, merged_params, socket)
-                rendered = await _render(socket)
-                diff = socket.diff(rendered)
-
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {"diff": diff}, "status": "ok"},
-                ]
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                continue
-
-            if event == "cids_will_destroy":
-                # Client notifies that these CIDs are being removed from DOM
-                # Actual cleanup handled by prune_stale_components() during render
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {}, "status": "ok"},
-                ]
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                continue
-
-            if event == "cids_destroyed":
-                # Client confirms CIDs have been fully removed from DOM
-                # Return the CIDs so client can prune its render cache
-                cids = payload.get("cids", [])
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {"cids": cids}, "status": "ok"},
-                ]
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                continue
-
-            if event == "allow_upload":
-                allow_upload_response = await socket.upload_manager.process_allow_upload(
-                    payload, socket.context
-                )
 
                 rendered = await _render(socket)
-                diff = socket.diff(rendered)
+                socket.prev_rendered = rendered
 
                 resp = [
                     joinRef,
@@ -311,146 +406,78 @@ class LiveSocketHandler:
                     topic,
                     "phx_reply",
                     {
-                        "response": {"diff": rendered} | allow_upload_response,
+                        "response": {
+                            "rendered": rendered,
+                            "liveview_version": PHOENIX_LIVEVIEW_VERSION,
+                        },
                         "status": "ok",
                     },
                 ]
 
                 await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                continue
+            return
 
-            # file upload or navigation
-            if event == "phx_join":
-                # Check if this is a file upload join (topic starts with "lvu:")
-                if topic.startswith("lvu:"):
-                    # This is a file upload join
-                    socket.upload_manager.add_upload(joinRef, payload)
+        if event == "chunk":
+            socket.upload_manager.add_chunk(joinRef, payload)  # type: ignore
 
-                    resp = [
-                        joinRef,
-                        messageRef,
-                        topic,
-                        "phx_reply",
-                        {"response": {}, "status": "ok"},
-                    ]
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {}, "status": "ok"},
+            ]
 
-                    await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                else:
-                    # This is a navigation join (topic starts with "lv:")
-                    # Navigation payload has 'redirect' field instead of 'url'
-                    url_str_raw = payload.get("redirect") or payload.get("url")
-                    url_str: str = (
-                        url_str_raw.decode("utf-8")
-                        if isinstance(url_str_raw, bytes)
-                        else str(url_str_raw)
-                    )
-                    url = urlparse(url_str)
-                    lv_class, path_params = self.routes.get(url.path)
-                    await self.check_auth(socket.websocket, lv_class)
+            if socket.upload_manager.no_progress(joinRef):
+                await self.manager.send_personal_message(
+                    json.dumps(
+                        [
+                            joinRef,
+                            None,
+                            myJoinId,
+                            "phx_reply",
+                            {"response": {"diff": {}}, "status": "ok"},
+                        ]
+                    ),
+                    socket.websocket,
+                )
 
-                    session = {}
-                    if "session" in payload:
-                        session = deserialize_session(payload["session"])
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
 
-                    lv = create_view(lv_class, session)
+        if event == "progress":
+            # Trigger progress callback BEFORE updating progress (which may consume the entry)
+            await socket.upload_manager.trigger_progress_callback_if_exists(payload, socket)
 
-                    # Create new socket for new LiveView
-                    socket = ConnectedLiveViewSocket(
-                        socket.websocket,
-                        topic,
-                        lv,
-                        self.scheduler,
-                        self.instrumentation,
-                        self.routes,
-                    )
+            await socket.upload_manager.update_progress(joinRef, payload, socket)
 
-                    await call_mount(lv, socket, session)
+            rendered = await _render(socket)
+            diff = socket.diff(rendered)
 
-                    # Parse query parameters and merge with path parameters
-                    query_params = parse_qs(url.query)
-                    merged_params = {**query_params, **path_params}
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {"diff": diff}, "status": "ok"},
+            ]
 
-                    await call_handle_params(lv, url, merged_params, socket)
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
 
-                    rendered = await _render(socket)
-                    socket.prev_rendered = rendered
+        if event == "phx_leave":
+            # Handle LiveView navigation - clean up current LiveView
+            await socket.close()
 
-                    resp = [
-                        joinRef,
-                        messageRef,
-                        topic,
-                        "phx_reply",
-                        {
-                            "response": {
-                                "rendered": rendered,
-                                "liveview_version": PHOENIX_LIVEVIEW_VERSION,
-                            },
-                            "status": "ok",
-                        },
-                    ]
-
-                    await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-
-            if event == "chunk":
-                socket.upload_manager.add_chunk(joinRef, payload)  # type: ignore
-
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {}, "status": "ok"},
-                ]
-
-                if socket.upload_manager.no_progress(joinRef):
-                    await self.manager.send_personal_message(
-                        json.dumps(
-                            [
-                                joinRef,
-                                None,
-                                myJoinId,
-                                "phx_reply",
-                                {"response": {"diff": {}}, "status": "ok"},
-                            ]
-                        ),
-                        socket.websocket,
-                    )
-
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-
-            if event == "progress":
-                # Trigger progress callback BEFORE updating progress (which may consume the entry)
-                await socket.upload_manager.trigger_progress_callback_if_exists(payload, socket)
-
-                await socket.upload_manager.update_progress(joinRef, payload, socket)
-
-                rendered = await _render(socket)
-                diff = socket.diff(rendered)
-
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {"diff": diff}, "status": "ok"},
-                ]
-
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-
-            if event == "phx_leave":
-                # Handle LiveView navigation - clean up current LiveView
-                await socket.close()
-
-                resp = [
-                    joinRef,
-                    messageRef,
-                    topic,
-                    "phx_reply",
-                    {"response": {}, "status": "ok"},
-                ]
-                await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
-                # Continue to wait for next phx_join
-                continue
+            resp = [
+                joinRef,
+                messageRef,
+                topic,
+                "phx_reply",
+                {"response": {}, "status": "ok"},
+            ]
+            await self.manager.send_personal_message(json.dumps(resp), socket.websocket)
+            return
 
 
 async def _render(socket: ConnectedLiveViewSocket):

--- a/tests/test_ws_handler_redirect.py
+++ b/tests/test_ws_handler_redirect.py
@@ -1,0 +1,167 @@
+"""Tests for WebSocket handler URL/redirect payload handling.
+
+Verifies that phx_join works with both 'url' and 'redirect' payload fields,
+matching the Phoenix LiveView client behavior where the JS client sends either
+'url' or 'redirect' but never both.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pyview.csrf import generate_csrf_token
+from pyview.instrumentation import NoOpInstrumentation
+from pyview.live_routes import LiveViewLookup
+from pyview.live_socket import ConnectedLiveViewSocket
+from pyview.live_view import LiveView
+from pyview.ws_handler import LiveSocketHandler
+
+
+class EmptyRendered:
+    def tree(self):
+        return {}
+
+    def text(self, socket=None):
+        return ""
+
+
+class MountingLiveView(LiveView[dict]):
+    async def mount(self, socket, session):
+        socket.context = {}
+
+    async def render(self, assigns, meta):
+        return EmptyRendered()
+
+
+def make_handler():
+    routes = LiveViewLookup()
+    routes.add("/demo", MountingLiveView)
+    handler = LiveSocketHandler(routes, NoOpInstrumentation())
+    return handler
+
+
+def make_websocket(payload):
+    websocket = MagicMock()
+    websocket.accept = AsyncMock()
+    websocket.send_text = AsyncMock()
+    websocket.receive_text = AsyncMock(
+        return_value=json.dumps(
+            ["1", "1", "lv:test", "phx_join", payload]
+        )
+    )
+    return websocket
+
+
+def suppress_close(monkeypatch):
+    """Suppress socket.close() to avoid cleanup errors in tests."""
+    async def fake_close(self):
+        pass
+    monkeypatch.setattr(ConnectedLiveViewSocket, "close", fake_close)
+
+
+async def test_phx_join_with_url_payload(monkeypatch):
+    """Standard phx_join with 'url' field works (regression guard)."""
+    handler = make_handler()
+    payload = {
+        "url": "http://testserver/demo",
+        "params": {"_csrf_token": generate_csrf_token("lv:test")},
+    }
+    websocket = make_websocket(payload)
+    suppress_close(monkeypatch)
+
+    async def stop_after_join(topic, socket):
+        pass  # Don't enter the connected loop
+
+    monkeypatch.setattr(handler, "handle_connected", stop_after_join)
+    await handler.handle(websocket)
+
+    # Should have sent a phx_reply with rendered content
+    websocket.send_text.assert_called_once()
+    resp = json.loads(websocket.send_text.call_args[0][0])
+    assert resp[3] == "phx_reply"
+    assert resp[4]["status"] == "ok"
+    assert "rendered" in resp[4]["response"]
+
+
+async def test_phx_join_with_redirect_payload(monkeypatch):
+    """phx_join with 'redirect' field instead of 'url' works.
+
+    The Phoenix LiveView JS client sends 'redirect' (not 'url') when
+    this.redirect is true (e.g. during live_redirect navigation).
+    """
+    handler = make_handler()
+    payload = {
+        "redirect": "http://testserver/demo",
+        "params": {"_csrf_token": generate_csrf_token("lv:test")},
+    }
+    websocket = make_websocket(payload)
+    suppress_close(monkeypatch)
+
+    async def stop_after_join(topic, socket):
+        pass
+
+    monkeypatch.setattr(handler, "handle_connected", stop_after_join)
+    await handler.handle(websocket)
+
+    # Should have sent a phx_reply with rendered content
+    websocket.send_text.assert_called_once()
+    resp = json.loads(websocket.send_text.call_args[0][0])
+    assert resp[3] == "phx_reply"
+    assert resp[4]["status"] == "ok"
+    assert "rendered" in resp[4]["response"]
+
+
+async def test_connected_loop_error_sends_error_reply_and_continues(monkeypatch):
+    """An error in one message shouldn't kill the WebSocket connection.
+
+    The handler should send an error reply and continue processing the next message.
+    """
+    from starlette.websockets import WebSocketDisconnect
+
+    handler = make_handler()
+    suppress_close(monkeypatch)
+
+    dispatch_count = 0
+    original_dispatch = handler._dispatch_event
+
+    async def counting_dispatch(*args, **kwargs):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        if dispatch_count == 1:
+            raise ValueError("simulated error")
+        # Second call: just return normally (heartbeat will be handled)
+        return await original_dispatch(*args, **kwargs)
+
+    handler._dispatch_event = counting_dispatch
+
+    # Three messages: bad one, heartbeat, then disconnect
+    messages = [
+        {"text": json.dumps(["1", "2", "lv:test", "event", {"bad": "payload"}])},
+        {"text": json.dumps([None, "3", "phoenix", "heartbeat", {}])},
+        {"type": "websocket.disconnect", "code": 1000},
+    ]
+
+    mock_socket = MagicMock(spec=ConnectedLiveViewSocket)
+    mock_socket.websocket = MagicMock()
+    mock_socket.websocket.receive = AsyncMock(side_effect=messages)
+    mock_socket.websocket.send_text = AsyncMock()
+
+    with pytest.raises(WebSocketDisconnect):
+        await handler._handle_connected_loop("lv:test", mock_socket)
+
+    # Should have dispatched twice (error on first, success on second)
+    assert dispatch_count == 2
+
+    # Verify an error reply was sent for the first message
+    sent_messages = [
+        json.loads(call[0][0])
+        for call in mock_socket.websocket.send_text.call_args_list
+    ]
+    error_replies = [m for m in sent_messages if m[4].get("status") == "error"]
+    assert len(error_replies) == 1
+    assert error_replies[0][3] == "phx_reply"
+
+    # Verify the heartbeat was also handled (ok reply)
+    ok_replies = [m for m in sent_messages if m[4].get("status") == "ok"]
+    assert len(ok_replies) == 1


### PR DESCRIPTION
## Summary

- Fix sporadic `KeyError` crash when the Phoenix LiveView JS client sends a `phx_join` payload with `redirect` instead of `url` (happens during `live_redirect` navigation)
- Extract event dispatch into `_dispatch_event` method with per-message error handling so one bad WebSocket message doesn't kill the entire connection
- Add defensive `.get()` access for `payload["url"]` in `live_patch` handler

## Root Cause

The Phoenix LiveView JS client sends **either** `url` or `redirect` in the `phx_join` payload, never both:

```js
url: this.redirect ? void 0 : url || void 0,
redirect: this.redirect ? url : void 0,
```

When `this.redirect` is true (e.g. during `live_redirect` navigation), the payload has `redirect` but no `url` key. pyview was unconditionally accessing `payload["url"]`, causing a `KeyError` that crashed the WebSocket connection. The client would reconnect (still with `redirect=true`), hit the same error, and loop — explaining the "goes crazy" behavior.

Phoenix (Elixir) handles this with three pattern-match clauses in `authorize_session/3`, including a catch-all for missing fields. The navigation join handler at line 341 already used the correct pattern (`payload.get("redirect") or payload.get("url")`), but the initial join at line 97 did not.

## Test plan

- [x] New test: `test_phx_join_with_url_payload` — regression guard for existing behavior
- [x] New test: `test_phx_join_with_redirect_payload` — verifies the fix
- [x] New test: `test_connected_loop_error_sends_error_reply_and_continues` — verifies per-message error resilience
- [x] All 411 existing tests pass
- [ ] Manual test with redirect repro example (`/redirect_a` and `/redirect_b` views)

https://claude.ai/code/session_01QAH3cTEsV7MbAz1pGB49QP