### PR TITLE
fix starlight social config and bump CI to node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Install dependencies
         working-directory: docs-site

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -18,9 +18,9 @@ export default defineConfig({
       logo: {
         src: './src/assets/pyview_logo_512.png',
       },
-      social: {
-        github: 'https://github.com/ogrodnek/pyview',
-      },
+      social: [
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/ogrodnek/pyview' },
+      ],
       customCss: ['./src/styles/custom.css'],
       sidebar: [
         { label: 'Home', slug: '' },


### PR DESCRIPTION
Starlight 0.33 changed `social` from an object to an array of link items — the old shape was breaking the docs build after the astro 6 bump. Also moves the docs workflow from node 22 to node 24 to match local dev.