### PR TITLE
Fix Starlight sidebar config for v0.39+

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -35,11 +35,11 @@ export default defineConfig({
         { label: 'Streams', slug: 'streams-usage' },
         {
           label: 'Core Concepts',
-          autogenerate: { directory: 'core-concepts' },
+          items: [{ autogenerate: { directory: 'core-concepts' } }],
         },
         {
           label: 'Templating',
-          autogenerate: { directory: 'templating' },
+          items: [{ autogenerate: { directory: 'templating' } }],
         },
         {
           label: 'Features',


### PR DESCRIPTION
## Summary

The recent Astro/Starlight dependency update broke `astro build` in CI. Starlight v0.39.0 removed support for the `autogenerate` + `label` shorthand on sidebar groups, causing the config validation to fail:

```
Found an `autogenerate` object with a `label`. Support for autogenerated
sidebar groups was removed in Starlight v0.39.0.
```

## Changes

Wrap each `autogenerate` config in an `items` array under the labeled group, as required by v0.39+:

```js
{
  label: 'Core Concepts',
  items: [{ autogenerate: { directory: 'core-concepts' } }],
},
{
  label: 'Templating',
  items: [{ autogenerate: { directory: 'templating' } }],
},
```

This affects the `Core Concepts` and `Templating` sidebar groups in `docs-site/astro.config.mjs`.

## Testing

- `npm run build` completes cleanly (24 pages built).

## Notes

- The `markdown.remarkPlugins` deprecation warning in the build output is non-fatal and left unchanged to keep this change focused on unblocking CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnQEcYSWu2oymeCCXYyskv)_