### PR TITLE
Remove dead code from core package

### DIFF
--- a/pyview/live_view.py
+++ b/pyview/live_view.py
@@ -1,5 +1,4 @@
 from typing import Any, Generic, Optional, TypeVar
-from urllib.parse import ParseResult
 
 from pyview.events import InfoEvent
 from pyview.meta import PyViewMeta
@@ -16,7 +15,6 @@ from .live_socket import ConnectedLiveViewSocket, LiveViewSocket
 T = TypeVar("T")
 
 Session = dict[str, Any]
-URL = ParseResult
 
 
 class LiveView(Generic[T]):

--- a/pyview/template/live_template.py
+++ b/pyview/template/live_template.py
@@ -17,11 +17,6 @@ class DataclassInstance(Protocol):
 Assigns = Union[dict[str, Any], DataclassInstance]
 
 
-# TODO: should we still support this?
-class DictConvertable(Protocol):
-    def asdict(self) -> dict[str, Any]: ...
-
-
 class LiveTemplate:
     t: Template
 

--- a/pyview/template/serializer.py
+++ b/pyview/template/serializer.py
@@ -15,14 +15,8 @@ def serialize(assigns: Any) -> dict[str, Any]:
     raise TypeError("Assigns must be a dict or have an asdict() method")
 
 
-def isprop(v) -> bool:
-    return isinstance(v, property)
-
-
 def prop_names(instance: Any) -> list[str]:
     """Returns a list of property names for the given class."""
-    # print(fields(cls))
-
     cls = instance.__class__
 
     return [prop for prop in cls.__dict__ if isinstance(cls.__dict__[prop], property)]


### PR DESCRIPTION
## Summary

Removes internal symbols that are defined but never referenced anywhere in the package, tests, or examples. Pure cleanup — no behavior change.

| Removed | File | Notes |
|---|---|---|
| `URL = ParseResult` alias (+ its import) | `pyview/live_view.py` | Module-level alias, never used; not in `__all__`. |
| `DictConvertable` Protocol | `pyview/template/live_template.py` | Unused Protocol carrying a `# TODO: should we still support this?`. Code uses `DataclassInstance` / `asdict()` instead. |
| `isprop()` + commented-out debug print | `pyview/template/serializer.py` | Never called; `prop_names()` inlines its own `isinstance(..., property)` check. |

## Verification

Each symbol was confirmed unused by grepping `pyview/`, `tests/`, `examples/`, and `docs/`. Public API and test-exercised helpers were deliberately left in place.

- `ruff check` — clean
- `pyright` — 0 errors
- `pytest` — 411 passed

Opened as a draft for review.

_Note: an earlier revision of this PR also removed `ActiveUploads.file_name()`. It was pulled back out — although unused and undocumented, `ActiveUploads` is reachable at runtime via `UploadConfig.uploads`, so it can't be ruled out as an external touch-point._